### PR TITLE
Adds support for fluid grids (width = 100% of active document)

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -10,6 +10,7 @@ module.exports = (grunt) ->
           'dist/Twitter Bootstrap 3 Grid Tablet.jsx':        ['src/grid.coffee','src/tablets.coffee']
           'dist/Twitter Bootstrap 3 Grid Desktop.jsx':       ['src/grid.coffee','src/desktops.coffee']
           'dist/Twitter Bootstrap 3 Grid Large Desktop.jsx': ['src/grid.coffee','src/large-desktops.coffee']
+          'dist/Twitter Bootstrap 3 Grid Fluid.jsx':         ['src/grid.coffee','src/fluid.coffee']
 
     mochaTest:
       files: ['test/**/*.coffee']

--- a/dist/Twitter Bootstrap 3 Grid Fluid.jsx
+++ b/dist/Twitter Bootstrap 3 Grid Fluid.jsx
@@ -100,7 +100,6 @@ if (typeof module !== "undefined" && module !== null) {
 }
 
 draw_grid({
-  width: grid_definitions.grid_desktop_width,
   columns: grid_definitions.grid_number_of_columns,
   gutter: grid_definitions.grid_half_gutter
 });

--- a/dist/Twitter Bootstrap 3 Grid Large Desktop.jsx
+++ b/dist/Twitter Bootstrap 3 Grid Large Desktop.jsx
@@ -84,6 +84,9 @@ draw_grid = function(grid_definition) {
   var active_ps_doc, grid, grid_to_ps;
   if (app.documents.length > 0) {
     active_ps_doc = app.activeDocument;
+    if (grid_definition.width == null) {
+      grid_definition.width = active_ps_doc.width;
+    }
     grid = new Grid(grid_definition);
     grid_to_ps = new GridToPs(active_ps_doc, grid);
     return grid_to_ps.draw();

--- a/dist/Twitter Bootstrap 3 Grid Tablet.jsx
+++ b/dist/Twitter Bootstrap 3 Grid Tablet.jsx
@@ -84,6 +84,9 @@ draw_grid = function(grid_definition) {
   var active_ps_doc, grid, grid_to_ps;
   if (app.documents.length > 0) {
     active_ps_doc = app.activeDocument;
+    if (grid_definition.width == null) {
+      grid_definition.width = active_ps_doc.width;
+    }
     grid = new Grid(grid_definition);
     grid_to_ps = new GridToPs(active_ps_doc, grid);
     return grid_to_ps.draw();

--- a/dist/Twitter Bootstrap 3 Grid iPhone Landscape.jsx
+++ b/dist/Twitter Bootstrap 3 Grid iPhone Landscape.jsx
@@ -84,6 +84,9 @@ draw_grid = function(grid_definition) {
   var active_ps_doc, grid, grid_to_ps;
   if (app.documents.length > 0) {
     active_ps_doc = app.activeDocument;
+    if (grid_definition.width == null) {
+      grid_definition.width = active_ps_doc.width;
+    }
     grid = new Grid(grid_definition);
     grid_to_ps = new GridToPs(active_ps_doc, grid);
     return grid_to_ps.draw();

--- a/dist/Twitter Bootstrap 3 Grid iPhone Portrait.jsx
+++ b/dist/Twitter Bootstrap 3 Grid iPhone Portrait.jsx
@@ -84,6 +84,9 @@ draw_grid = function(grid_definition) {
   var active_ps_doc, grid, grid_to_ps;
   if (app.documents.length > 0) {
     active_ps_doc = app.activeDocument;
+    if (grid_definition.width == null) {
+      grid_definition.width = active_ps_doc.width;
+    }
     grid = new Grid(grid_definition);
     grid_to_ps = new GridToPs(active_ps_doc, grid);
     return grid_to_ps.draw();

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ Hit download and copy the \*.jsx files files from the *dist directory*
 - Twitter Bootstrap 3 Grid Tablet.jsx
 - Twitter Bootstrap 3 Grid iPhone Landscape.jsx
 - Twitter Bootstrap 3 Grid iPhone Portrait.jsx
+- Twitter Bootstrap 3 Grid Fluid.jsx
 
 into your the following folder
 

--- a/src/fluid.coffee
+++ b/src/fluid.coffee
@@ -1,0 +1,3 @@
+draw_grid
+  columns: grid_definitions.grid_number_of_columns
+  gutter:  grid_definitions.grid_half_gutter

--- a/src/grid.coffee
+++ b/src/grid.coffee
@@ -44,6 +44,8 @@ GridToPs = class GridToPs
 draw_grid = (grid_definition) ->
   if app.documents.length > 0
     active_ps_doc = app.activeDocument
+    if not grid_definition.width?
+      grid_definition.width = active_ps_doc.width
 
     grid = new Grid(grid_definition)
     grid_to_ps = new GridToPs(active_ps_doc, grid)


### PR DESCRIPTION
Our UI team needed this because our app if full-width (_i.e._ we wrap our page in a `div.container-fluid`), and we also needed columns within existing elements (_e.g_ `div.panel`s) that we designed in separate smart objects, that needed their own grid.